### PR TITLE
Update verifySignature.js

### DIFF
--- a/lib/payouts/services/verifySignature.js
+++ b/lib/payouts/services/verifySignature.js
@@ -11,8 +11,8 @@ const verifySignature = (body, signature, clientSecret) => {
 
   const expectedSignature = crypto
     .createHmac('sha256', clientSecret)
-    .update(body.toString())
-    .digest('hex');
+    .update(body)   //toString() is not required
+    .digest('base64');    //the encrypted data is to be encoded to base64 instead of hex
 
   return expectedSignature === signature;
 };


### PR DESCRIPTION
Checked this piece of code and found that the returned signature was not matching with the response data signature from Cashfree servers. After making the following changes, the generated signature was matching. Hope this helps.