### PR TITLE
IMPORTANT : Fixed 'verifySignature' function in lib/payouts/services

### DIFF
--- a/lib/payouts/services/verifySignature.js
+++ b/lib/payouts/services/verifySignature.js
@@ -12,7 +12,7 @@ const verifySignature = (body, signature, clientSecret) => {
   if(typeof body == 'string'){
     // if user sends body as string of concatenated values of keys except 'signature'
 
-    const expectedSignature = crypto.createHmac('sha256', process.env.CASHFREE_CLIENT_SECRET).update(body).digest('base64');
+    const expectedSignature = crypto.createHmac('sha256', clientSecret).update(body).digest('base64');
     return expectedSignature === signature;
   
   }else if(typeof body == 'object'){
@@ -43,7 +43,7 @@ const verifySignature = (body, signature, clientSecret) => {
       concatenatedValues+=arr[i][1];
     }
 
-    const expectedSignature = crypto.createHmac('sha256', process.env.CASHFREE_CLIENT_SECRET).update(concatenatedValues).digest('base64');
+    const expectedSignature = crypto.createHmac('sha256', clientSecret).update(concatenatedValues).digest('base64');
     return expectedSignature === signature;
 
   }else{

--- a/lib/payouts/services/verifySignature.js
+++ b/lib/payouts/services/verifySignature.js
@@ -3,18 +3,58 @@ const crypto = require('crypto');
 const verifySignature = (body, signature, clientSecret) => {
   if (!(body && signature && clientSecret)) {
     throw Error(
-      'Invalid Parameters: Please give request body,' +
-        'signature sent in X-Cf-Signature header and ' +
-        'clientSecret from dashboard as parameters',
+      'Invalid Parameters: Please give request body (which is postData in Cashfree Documentation) ,' +
+        'signature sent as X-Cf-Signature in header or as signature key in body and ' +
+        'clientSecret from cashfree dashboard as parameters',
     );
   }
 
-  const expectedSignature = crypto
-    .createHmac('sha256', clientSecret)
-    .update(body.toString())
-    .digest('hex');
+  if(typeof body == 'string'){
+    // if user sends body as string of concatenated values of keys except 'signature'
 
-  return expectedSignature === signature;
+    const expectedSignature = crypto.createHmac('sha256', process.env.CASHFREE_CLIENT_SECRET).update(body).digest('base64');
+    return expectedSignature === signature;
+  
+  }else if(typeof body == 'object'){
+    // else if user sends body as entire json request-body, 
+    // then we need to create a string of concatenated "values" of body sorted in "ascending" order of keys
+    // as explained in "Documentation" and pass it for encryption
+
+    // if signature is present in the body delete signature first before creating the string
+    if(body.signature){
+      delete body.signature
+    }
+
+    // get an array of [ key, value ] pairs of body object
+    let arr = Object.entries(body);
+
+    // sort them in ascending order of "keys", here in [key, value] pairs
+    arr.sort((a, b)=>{
+        if(a[0] < b[0]){
+            return -1;
+        }else{
+            return 1;
+        }
+    })
+
+    // concatenate values of body which is now sorted in ascending order of "keys", 
+    let concatenatedValues = "";
+    for(let i=0;i<arr.length;i++){
+      concatenatedValues+=arr[i][1];
+    }
+
+    const expectedSignature = crypto.createHmac('sha256', process.env.CASHFREE_CLIENT_SECRET).update(concatenatedValues).digest('base64');
+    return expectedSignature === signature;
+
+  }else{
+    // else can't compute the body, we don't know what type of body has been sent as parameters
+    
+    throw Error(
+      'Invalid Parameters: Please give request body (which is postData in Cashfree Documentation),' +
+        'signature sent as X-Cf-Signature in header or as signature key in body and ' +
+        'clientSecret from cashfree dashboard as parameters',
+    );
+  }
 };
 
 module.exports = verifySignature;


### PR DESCRIPTION
-- IMPORTANT: Fixed the 'verifySignature' function in lib/payouts/services.

-- In the documentation, it was written that "postData" should be a string of concatenated values of the request-body object, which should be created by sorting keys in "descending" order, excluding the "signature" key and encryption type should be set to "base64". 
                      
But in function, it is treating the body as "object" and converting it using "toString()" then encrypting it in "hex" rather than "base64", which is now fixed.

-- Additionally, it can now beautifully handle the "typeof" body as "String" as well as "Object", which is raw request-body JSON-object, then encrypt and test it respectively, this feature was created due to the lack of information on what type of data should "postData" send to the "body" parameter of the function.